### PR TITLE
添加编译打包配置，方便部署，进而提供低版本浏览器支持

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,10 @@
+{
+    "presets": [
+        ["@babel/preset-env", {
+            "targets": {
+                "browsers": ["> 1%", "last 2 versions"]
+            }
+        }]
+    ],
+    "plugins": ["@babel/transform-runtime"]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,36 @@
+# Packages
+node_modules
+
+# Output
+build
+dist
+docs/_book
+src/version.js
+junit.xml
+coverage/
+.docz/
+
+# YALC (for Erik)
+.yalc
+yalc.lock
+
+# Logging, System files, misc.
+.idea/
+.npm
+npm-debug.log
+package-lock.json
+yarn-error.log
+.DS_Store
+.env
+
+# Common Example Data Directories
+sampledata/
+example/deps/
+docker/dcm4che/dcm4che-arc
+
+# Cypress test results
+videos/
+screenshots/
+
+# Locize settings
+.locize

--- a/README.md
+++ b/README.md
@@ -2,3 +2,29 @@
 一套类似word或wps用于文字排版相关功能的代码件，有Delphi、C#、Html5、C++(暂未完成)四个版本，可用在电子病历或其他文书系统里。
 [http://hcview.cn/](http://hcview.cn/)是一个在线的示例，你也可以加入QQ群 649023932 来获取更多的技术交流。
 ![图片说明](https://github.com/59079096/hcview-H5/blob/master/page.png)
+
+## 开发
+### 说明
+本项目使用纯JavaScript开发，不依赖任何一款JavaScript插件、框架。 你可以不需要安装后续文档中的`nodejs`工具，以及配置中依赖的插件。后续这些操作，都是为了打包项目的需要。 
+
+### 开发要求
+- [Node 10+](https://npm.taobao.org/mirrors/node/v10.18.1/)
+
+### 准备开始
+```bash
+# 因默认npm registry访问缓慢，请替换为国内的镜像
+npm config set registry https://registry.npm.taobao.org 
+# 或者安装cnpm(强烈建议)
+npm install -g cnpm --registry=https://registry.npm.taobao.org
+
+
+# 还原依赖
+cnpm install
+
+# 运行项目, 访问http://localhost:8080
+cnpm run dev
+
+# 编译项目, 所有输出在dist目录
+cnpm run build
+
+```

--- a/html-templates/index.html
+++ b/html-templates/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+  <meta name="theme-color" content="#000000" />
+  <meta name="mobile-web-app-capable" content="yes">
+  <meta name="application-name" content="OHIF Viewer">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+  <meta name="apple-mobile-web-app-title" content="HCView Demo">
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+  <title>HCView Demo</title>
+  <!--低版本浏览器兼容脚本，可以只选择需要的部分：https://polyfill.io/v3/url-builder/-->
+  <script src="https://polyfill.alicdn.com/v3/polyfill.min.js"></script>
+</head>
+
+<body>
+
+</body>
+
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "hcview-h5",
+  "version": "1.0.0",
+  "description": "一套类似word或wps用于文字排版相关功能的代码件，有Delphi、C#、Html5、C++(暂未完成)四个版本，可用在电子病历或其他文书系统里。\r [http://hcview.cn/](http://hcview.cn/)是一个在线的示例，你也可以加入QQ群 649023932 来获取更多的技术交流。\r ![图片说明](https://github.com/59079096/hcview-H5/blob/master/page.png)",
+  "main": "HCViewDemo.js",
+  "scripts": {
+    "dev": "webpack-dev-server --progress --colors --devtool source-map --hot --inline",
+    "build": "webpack --progress --colors"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/59079096/HCView-H5.git"
+  },
+  "keywords": [
+    "emreditor",
+    "richview",
+    "richeditor"
+  ],
+  "author": "59079096",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/59079096/HCView-H5/issues"
+  },
+  "homepage": "https://github.com/59079096/HCView-H5#readme",
+  "devDependencies": {
+    "@babel/core": "^7.9.0",
+    "@babel/plugin-transform-runtime": "^7.9.0",
+    "@babel/preset-env": "^7.9.0",
+    "@babel/runtime": "^7.9.2",
+    "babel-core": "^6.26.3",
+    "babel-loader": "^8.1.0",
+    "babel-plugin-transform-runtime": "^6.23.0",
+    "babel-polyfill": "^6.26.0",
+    "babel-preset-env": "^1.7.0",
+    "babel-preset-es2015": "^6.24.1",
+    "copy-webpack-plugin": "^5.1.1",
+    "html-webpack-plugin": "^3.2.0",
+    "webpack": "^4.42.0",
+    "webpack-cli": "^3.3.11",
+    "webpack-dev-server": "^3.10.3"
+  },
+  "dependencies": {
+    "@babel/polyfill": "^7.8.7"
+  }
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,49 @@
+//为了使用插件，需要将require()其添加到plugins阵列中。使用new运算符调用插件来创建插件的实例。
+const htmlwebpackplugin = require("html-webpack-plugin");
+const copywebpackplugin = require("copy-webpack-plugin");
+const webpack = require("webpack");
+const path = require("path");
+module.exports = {
+  entry: {
+    index: "./HCViewDemo.js"
+  },
+  output: {
+    filename: "app.bundle.[hash:5].js",
+    path: __dirname + "/dist"
+  },
+  module: {
+    rules: [
+      {
+        test: /(\.js)$/,
+        use: {
+          loader: "babel-loader",
+          options: {
+            presets: [
+              [
+                "@babel/preset-env",
+                {
+                  targets: {
+                    browsers: ["> 1%", "last 2 versions"]
+                  }
+                }
+              ]
+            ]
+          }
+        }
+      }
+    ]
+  },
+  plugins: [
+    new htmlwebpackplugin({ template: "./html-templates/index.html" }),
+    new copywebpackplugin([
+      {
+        from: __dirname + "/image",
+        to: __dirname + "/dist/image"
+      },
+      {
+        from: __dirname + "/favicon.ico",
+        to: __dirname + "/dist/favicon.ico"
+      }
+    ])
+  ]
+};


### PR DESCRIPTION
1. 添加编译打包配置。
2. html-templates\index.html是为了方便编译输出而添加的模板文件。
3. 更新README.md，添加编译打包说明。